### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # work on DOTT itself (i.e., add new features, fix bugs, ...)
 dott-ng-runtime>=1.1.2,==2.13.*
 pygdbmi==0.11.0.0
-pylink-square==0.11.1
+pylink-square>=1.0,<2.0
 pytest
 lxml
 


### PR DESCRIPTION
To be compatible with more recent versions of pyOCD, the pylink-square requirement needs to be relaxed.